### PR TITLE
fix(eslint-config): improve TypeScript integration and add essential rules

### DIFF
--- a/packages/eslint-config/eslint.config.ts
+++ b/packages/eslint-config/eslint.config.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import { defineConfig } from "eslint/config";
 import { node } from "./src/node/index.js";
 
@@ -5,7 +7,9 @@ export default defineConfig(node, {
   languageOptions: {
     parserOptions: {
       tsconfigRootDir: import.meta.dirname,
-      projectService: true,
+      projectService: {
+        allowDefaultProject: ["*.config.ts"],
+      },
     },
   },
 });

--- a/packages/eslint-config/src/base/eslint.ts
+++ b/packages/eslint-config/src/base/eslint.ts
@@ -1,4 +1,9 @@
 import eslint from "@eslint/js";
 import { defineConfig } from "eslint/config";
 
-export const eslintConfig = defineConfig(eslint.configs.recommended);
+export const eslintConfig = defineConfig(eslint.configs.recommended, {
+  rules: {
+    eqeqeq: "error",
+    "object-shorthand": "error",
+  },
+});

--- a/packages/eslint-config/tsconfig.json
+++ b/packages/eslint-config/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "@kasoa/tsconfig/node.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist"
   },
   "exclude": ["node_modules", "dist"],
-  "include": ["src", "*.config.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
- Fix projectService config to allow default project for config files
- Add Node.js types reference for better IDE support
- Include eqeqeq and object-shorthand rules for code quality
- Clean up tsconfig to focus on src directory only