### PR TITLE
Fix Vite+ shared check defaults

### DIFF
--- a/.changeset/friendly-react-vite-checks.md
+++ b/.changeset/friendly-react-vite-checks.md
@@ -1,0 +1,5 @@
+---
+"@kasoa/vite-plus-config": patch
+---
+
+Ignore dependency/build output folders in the shared format and lint defaults so Vite+ checks do not crawl `node_modules` or generated bundles when a consumer has a sparse ignore file. The React preset now enables browser globals by default; React Native and Expo projects that want to reject DOM globals can override `lint.env.browser` to `false`.

--- a/packages/vite-plus-config/README.md
+++ b/packages/vite-plus-config/README.md
@@ -143,8 +143,8 @@ Use one `vite.config.ts` by default, then keep separate config files only when a
 
 ## Configurations
 
-- **`base`**: Strict TypeScript-first format, lint, type-aware/type-check defaults, test include, and staged-file defaults.
-- **`react`**: `base` plus React lint rules and Tailwind-aware formatting.
+- **`base`**: Strict TypeScript-first format, lint, type-aware/type-check defaults, dependency/build ignores, test include, and staged-file defaults.
+- **`react`**: `base` plus browser globals, React lint rules, and Tailwind-aware formatting. React Native or Expo projects that want to reject DOM globals can override `lint.env.browser` to `false`.
 - **`node`**: `base` plus Node-oriented lint rules.
 - **`library`**: `base` plus ESM-only packaging defaults for `vp pack`.
 - **`monorepo`**: `base` plus root-only `run` defaults for workspace caching.

--- a/packages/vite-plus-config/src/shared/constants.ts
+++ b/packages/vite-plus-config/src/shared/constants.ts
@@ -1,5 +1,8 @@
 export const DEFAULT_TEST_INCLUDE = ["**/*.{test,spec}.{ts,tsx,mts,cts}"] as const;
-export const GENERATED_FILE_IGNORE_PATTERNS = [
+export const DEFAULT_IGNORE_PATTERNS = [
+  "node_modules/**",
+  "dist/**",
+  "dist-ssr/**",
   "**/worker-configuration.d.ts",
   "**/migrations/**",
   "**/drizzle/migrations.js",

--- a/packages/vite-plus-config/src/shared/fmt.ts
+++ b/packages/vite-plus-config/src/shared/fmt.ts
@@ -1,10 +1,10 @@
 import type { UserConfig } from "vite-plus";
-import { GENERATED_FILE_IGNORE_PATTERNS } from "./constants.ts";
+import { DEFAULT_IGNORE_PATTERNS } from "./constants.ts";
 
 type FmtConfig = NonNullable<UserConfig["fmt"]>;
 
 export const baseFmt: FmtConfig = {
-  ignorePatterns: [...GENERATED_FILE_IGNORE_PATTERNS],
+  ignorePatterns: [...DEFAULT_IGNORE_PATTERNS],
   sortImports: {
     internalPattern: ["#", "@/"],
     newlinesBetween: false,

--- a/packages/vite-plus-config/src/shared/lint.ts
+++ b/packages/vite-plus-config/src/shared/lint.ts
@@ -1,5 +1,5 @@
 import type { UserConfig } from "vite-plus";
-import { GENERATED_FILE_IGNORE_PATTERNS } from "./constants.ts";
+import { DEFAULT_IGNORE_PATTERNS } from "./constants.ts";
 
 export const BASE_LINT_PLUGINS = ["typescript", "unicorn", "oxc", "import", "promise"] as const;
 
@@ -7,7 +7,7 @@ type LintConfig = NonNullable<UserConfig["lint"]>;
 
 const baseLintConfig: LintConfig = {
   plugins: [...BASE_LINT_PLUGINS],
-  ignorePatterns: [...GENERATED_FILE_IGNORE_PATTERNS],
+  ignorePatterns: [...DEFAULT_IGNORE_PATTERNS],
   env: {
     serviceworker: true,
     worker: true,
@@ -176,6 +176,9 @@ export const baseLint: LintConfig = baseLintConfig;
 
 const reactLintConfig: LintConfig = {
   plugins: ["react", "jsx-a11y"],
+  env: {
+    browser: true,
+  },
   rules: {
     "jsx-a11y/alt-text": "error",
 


### PR DESCRIPTION
## Why

New Vite projects using the shared Vite+ config could appear to hang when checks crawled dependency or build output folders. React web apps also reported browser globals like `document` as undefined, which made the React preset noisy for normal Vite React usage.

## What changed

- Added shared default ignores for `node_modules`, `dist`, and `dist-ssr` in both format and lint config.
- Enabled browser globals in the React preset.
- Documented how React Native / Expo projects can opt out of browser globals with `lint.env.browser: false`.
- Added a patch changeset for `@kasoa/vite-plus-config`.

## Verification

- `pnpm --filter @kasoa/vite-plus-config check`
- `pnpm --filter @kasoa/vite-plus-config build`
- `pnpm check`
- Temp Vite repro confirmed the shared ignore patch prevents dependency crawling even when the consumer `.gitignore` does not ignore `node_modules`.
- Temp Vite repro confirmed browser globals remove the false `document is not defined` error, and `lint.env.browser: false` restores it for Expo/React Native-style opt-out.

## Notes / risks

The plugin type loosening remains in place. Reverting it in a temp project still reproduces the TypeScript excessive stack depth error, so it is a separate real fix from this dependency-crawl issue.
